### PR TITLE
Verify threshold ecdsa signatures with RustCrypto

### DIFF
--- a/src/schnorr.rs
+++ b/src/schnorr.rs
@@ -163,7 +163,7 @@ mod tests {
     fn test_schnorr_circuit() {
         // Run through the schnorr protocol
         let group = GroupSpec::new();
-        let (g_r1, g_r2, r1, r2) = preprocess_mod(&group);
+        let (_, _, _, _) = preprocess_mod(&group);
         // let run_schnorr(Nat::from_u16(1337), true, g_r1, g_r2, r1, r2, group);
     }
 }


### PR DESCRIPTION
This PR changes two things that were stopping our signatures from validating with rustcrypto:

- Change `hash_message` to serialize using big endian
- Normalize `s` from the threshold signature before calling RustCrypto verify

The normalization of `s` is done by computing `-s mod ORDER` if `s >= ORDER / 2`. This is OK to do since both `s` and `-s mod ORDER` are valid for the signature, don't really know why this is, but [ECDSA on wiki]() also remarks this.

It was kind of funny - I first fixed the hash, and could see that the test was passing about half of the times. Then I found [this check](https://github.com/RustCrypto/elliptic-curves/blob/master/k256/src/ecdsa.rs#L203), that they perform during verification. There's a link in [the doc string](https://github.com/rustcrypto/signatures/blob/master/ecdsa/src/lib.rs#L318) for `normalize_s` which describes why they do this. 